### PR TITLE
Pin pnpm version to 10.19.0 across workspace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 # Production Image with Nginx
 FROM nginx:alpine
 
-# Install Node.js and pnpm for the backend
+# Install Node.js and pnpm for the backend.
+# pnpm must be pinned to the same version as the "packageManager" field of the
+# workspace: an unpinned install now resolves to pnpm 11, which tries to
+# self-switch to the pinned 10.x release and fails on Alpine, because
+# @pnpm/exe@10.x publishes no musl platform binary ("Cannot verify the identity
+# of the @pnpm/exe.linux-x64 native binary: it is missing from pnpm-lock.yaml").
+ARG PNPM_VERSION=10.19.0
 RUN apk add --update nodejs npm && \
-    npm install -g pnpm
+    npm install -g pnpm@${PNPM_VERSION}
 
 # Create application directories
 RUN mkdir -p /var/www/frontend /var/www/backend

--- a/DockerfileComplete
+++ b/DockerfileComplete
@@ -23,8 +23,10 @@ RUN wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | apt-key add -
     && apt-get install -y mongodb-org \
     && rm -rf /var/lib/apt/lists/*
 
-# Install pnpm
-RUN npm install -g pnpm
+# Install pnpm, pinned to the "packageManager" version of the workspace so that
+# pnpm never has to self-switch to another release at image build time.
+ARG PNPM_VERSION=10.19.0
+RUN npm install -g pnpm@${PNPM_VERSION}
 
 # Create necessary directories
 RUN mkdir -p /data/db /var/run/redis

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,7 @@
     "keywords": [],
     "author": "",
     "license": "ISC",
-    "packageManager": "pnpm@10.7.0",
+    "packageManager": "pnpm@10.19.0",
     "dependencies": {
         "@aws-sdk/client-s3": "^3.943.0",
         "@aws-sdk/s3-request-presigner": "^3.943.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "version": "0.0.0",
     "type": "module",
-    "packageManager": "pnpm@8.10.0",
+    "packageManager": "pnpm@10.19.0",
     "engines": {
         "node": ">=21.0.0"
     },


### PR DESCRIPTION
## Summary
This PR standardizes the pnpm package manager version across the entire workspace by pinning it to version 10.19.0 in all package.json files and Docker configurations.

## Key Changes
- Updated `packageManager` field in `backend/package.json` from `10.7.0` to `10.19.0`
- Updated `packageManager` field in `frontend/package.json` from `8.10.0` to `10.19.0`
- Modified `Dockerfile` to explicitly pin pnpm installation to `10.19.0` using an ARG variable
- Modified `DockerfileComplete` to explicitly pin pnpm installation to `10.19.0` using an ARG variable
- Added detailed comments explaining why pnpm version pinning is necessary for Alpine Linux compatibility

## Implementation Details
The pnpm version is now pinned at the Docker build level to prevent version resolution issues. Previously, unpinned pnpm installations would resolve to newer versions (e.g., pnpm 11), which would then attempt to self-switch to the pinned workspace version. This self-switching process fails on Alpine Linux because @pnpm/exe@10.x does not publish musl platform binaries, resulting in verification errors.

By explicitly installing the pinned version during image build, we avoid the self-switch mechanism entirely and ensure consistent behavior across all environments.

https://claude.ai/code/session_01LTeYGzZCFqrMANzzbE76cG