### PR TITLE
Pin the infrastructure to 2.3.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
       retries: 5
 
   mfe-orchestrator:
-    image: lory1990/mfe-orchestrator:latest
+    image: lory1990/mfe-orchestrator:2.3.0
     container_name: mfe-orchestrator
     restart: always
     ports:

--- a/helm/mfe-orchestrator/Chart.yaml
+++ b/helm/mfe-orchestrator/Chart.yaml
@@ -4,9 +4,9 @@ description: Microfrontend Orchestrator - JSON based configuration, versioning a
 type: application
 
 # Chart version: bumped on every change to the chart itself.
-version: 0.1.0
+version: 0.1.1
 # Version of the mfe-orchestrator image shipped by default (see values.yaml image.tag).
-appVersion: "latest"
+appVersion: "2.3.0"
 
 home: https://github.com/mfe-orchestrator/mfe-orchestrator
 sources:

--- a/terraform/modules/microfronted-orchestrator-hub.tf
+++ b/terraform/modules/microfronted-orchestrator-hub.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "microfrontend_orchestrator_hub" {
-  name         = "lory1990/mfe-orchestrator:latest"
+  name         = "lory1990/mfe-orchestrator:2.3.0"
   keep_locally = true
 }
 resource "docker_container" "microfrontend_orchestrator_hub" {


### PR DESCRIPTION
Compose file, modulo Terraform e chart Helm puntavano a `latest`: ora nominano il tag `2.3.0`, che viene staccato subito dopo questo merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)